### PR TITLE
https links to avoid mixed-content MathJax error

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -45,7 +45,7 @@
 ###test2
 $x^2=1$
 
-[Google](http://google.com)
+[Google](https://google.com)
 ~~~~{python}
 print 'hello world'
 ~~~~
@@ -56,7 +56,7 @@ test `test`</textarea>
         <script src="lib/jquery.js"></script>
         <script src="lib/showdown.js"></script>
         <script src="template/js/prism.js"></script>
-        <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         <script type="text/x-mathjax-config">
           MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ["\\(","\\)"]], processEscapes: true}});
         </script>


### PR DESCRIPTION
https://isnowfy.github.io/simple/editor.html currently doesn't render math because MathJax script is considered mixed-content and doesn't load.
google.com link doesn't matter, changed just to advertise TLS and privacy :-)